### PR TITLE
GH-8: temporary workaround for authorization error while using JWT tokens

### DIFF
--- a/autoconfigure/src/main/java/io/mzlnk/springframework/multitenant/oauth2/resourceserver/AutoConfiguration.java
+++ b/autoconfigure/src/main/java/io/mzlnk/springframework/multitenant/oauth2/resourceserver/AutoConfiguration.java
@@ -42,7 +42,6 @@ public class AutoConfiguration {
     }
 
     @Bean
-    @Order(1)
     public AuthenticationTenantContextFilter authenticationTenantContextFilter(MultitenantAuthenticationManagerResolver resolver) {
         return new AuthenticationTenantContextFilter(resolver);
     }

--- a/autoconfigure/src/main/java/io/mzlnk/springframework/multitenant/oauth2/resourceserver/context/AuthenticationTenantContextFilter.java
+++ b/autoconfigure/src/main/java/io/mzlnk/springframework/multitenant/oauth2/resourceserver/context/AuthenticationTenantContextFilter.java
@@ -1,6 +1,7 @@
 package io.mzlnk.springframework.multitenant.oauth2.resourceserver.context;
 
 import io.mzlnk.springframework.multitenant.oauth2.resourceserver.resolver.MultitenantAuthenticationManagerResolver;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionAuthenticatedPrincipal;
@@ -14,8 +15,12 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Optional;
 
+import static io.mzlnk.springframework.multitenant.oauth2.resourceserver.context.AuthenticationTenantContextFilter.ORDER;
+
+@Order(ORDER)
 public class AuthenticationTenantContextFilter extends OncePerRequestFilter {
 
+    public static final int ORDER = 4000;
     private final MultitenantAuthenticationManagerResolver resolver;
 
     public AuthenticationTenantContextFilter(MultitenantAuthenticationManagerResolver resolver) {

--- a/autoconfigure/src/main/java/io/mzlnk/springframework/multitenant/oauth2/resourceserver/resolver/jwt/JwtAuthenticationManagerResolver.java
+++ b/autoconfigure/src/main/java/io/mzlnk/springframework/multitenant/oauth2/resourceserver/resolver/jwt/JwtAuthenticationManagerResolver.java
@@ -52,7 +52,7 @@ public class JwtAuthenticationManagerResolver implements AuthenticationManagerRe
         }
 
         public JwtAuthenticationManagerResolver build() {
-            return new JwtAuthenticationManagerResolver(this.publicKeyResolver, this.trustedIssuerResolver);
+            return new JwtAuthenticationManagerResolver(this.trustedIssuerResolver, this.publicKeyResolver);
         }
 
     }


### PR DESCRIPTION
In scope of this PR:
- added temporary workaround for authorization failed error caused by changes in spring security implementation
- changed `AuthenticationTenantContextFilter` order value to `4000` and moved to a public constant